### PR TITLE
Improves timeline for loglov3, etc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,14 @@
 Request Timeline
 ================
 
-This application displays log entries representing HTTP requests visually on a timeline.
-It depends on services logging according to the [Standard Log Format](https://wiki:8443/display/CP/Log+Attribute+Standards).
+This application displays log entries representing HTTP requests
+visually on a timeline.  It depends on services logging according to the
+[common OTLs][1]--specifically, ot-v1, msg-v1, and http-v1.
 
-The service is deployed on the `opengrok` machine, in `/var/www/request-timeline`.  It automatically updates to the latest `master` code
-every 10 minutes via a job in `/etc/cron.d/request-timeline`.
+The service is deployed on the `opengrok` machine, in
+`/var/www/request-timeline`.  It automatically updates to the latest
+`master` code every 10 minutes via a job in
+`/etc/cron.d/request-timeline`.
 
 Development Setup
 -----------------
@@ -14,3 +17,5 @@ Development Setup
     npm run compile
     npm install bower
     node_modules/bower/bin/bower install
+
+[1]: https://github.com/opentable/logging-loglov3-config/tree/master/otls

--- a/css/request.scss
+++ b/css/request.scss
@@ -38,9 +38,8 @@ table#logs tr {
 .vis-timeline .vis-item:not(.vis-selected).httpError {
   background-color: red;
 }
-
-.vis-timeline .vis-item:not(.vis-selected).request {
-  background-color: #B562CF !important;
+.vis-timeline .vis-item:not(.vis-selected).statusOther {
+  background-color: #B562CF;
 }
 
 body {

--- a/css/request.scss
+++ b/css/request.scss
@@ -16,7 +16,7 @@ table#logs tr {
   cursor: pointer;
 }
 
-#table-logmessage {
+#table-message {
   width: 70%;
 }
 

--- a/css/request.scss
+++ b/css/request.scss
@@ -62,7 +62,7 @@ html {
   margin-top: 15px;
 }
 
-span#duration, span#renderduration, span#nreqs {
+span#duration, span#renderduration, span#ngentries, span#ntentries {
   font-weight: bold;
 }
 

--- a/index.html
+++ b/index.html
@@ -65,9 +65,9 @@
     <table id="logs" class="table table-striped">
       <thead>
         <th>Timestamp</th>
-        <th id="table-severity">Severity</th>
-        <th id="table-servicetype">Service Type</th>
-        <th id="table-logmessage">Logmessage</th>
+        <th id="table-componentid">Component ID</th>
+        <th id="table-severity">Severity/Method</th>
+        <th id="table-message">Message/URL</th>
       </thead>
       <tbody>
       </tbody>

--- a/index.html
+++ b/index.html
@@ -48,6 +48,9 @@
         <label class="btn btn-primary active" id="outgoing">
           <input type="checkbox"  autocomplete="off" checked> Outgoing
         </label>
+        <label class="btn btn-primary active" id="other">
+          <input type="checkbox" autocomplete="off" checked> Other
+        </label>
       </div>
 
       <div id="metadata">

--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
       <div class="navbar-collapse collapse">
         <form class="navbar-form navbar-right" role="form">
           <div class="form-group">
-              <input type="search" id="requestid" placeholder="Request Id" autocomplete="false" autofocus="true" required="true" size=40 class="form-control" />
+              <input type="search" id="requestid" placeholder="Request ID" autocomplete="false" autofocus="true" required="true" size=40 class="form-control" />
           </div>
           <div class="form-group">
               <input type="text" id="searchdate" class="form-control" />

--- a/index.html
+++ b/index.html
@@ -41,6 +41,25 @@
   </div>
   <div class="container" id="timeline-content">
     <div class="header-wrapper">
+      <p>
+        Only log entries that have the <code>url</code> and
+        <code>duration</code> fields (our proxy for whether the message
+        accords to <strong>http-v1</strong>) will be displayed
+        graphically, and will be broken down by <em>incoming</em> and
+        <em>outgoing</em> (according to the <strong>http-v1</strong>
+        <code>incoming</code> boolean field), as well as log entries
+        missing that delineation
+        <!--
+          Hair space after italic r to avoid colliding with right paren.
+        -->
+        (<em>other</em>&#8202;).
+        <em>All</em> log entries will be displayed in the lower table.
+      </p>
+      <p>
+        Timeline queries both legacy and loglov3, so duplicate entries
+        may appear if services with the desired request ID are present
+        in both systems.
+      </p>
       <div class="btn-group" data-toggle="buttons" id="toggleLogType">
         <label class="btn btn-primary active" id="incoming">
           <input type="checkbox" autocomplete="off" checked> Incoming

--- a/index.html
+++ b/index.html
@@ -42,11 +42,11 @@
   <div class="container" id="timeline-content">
     <div class="header-wrapper">
       <div class="btn-group" data-toggle="buttons" id="toggleLogType">
+        <label class="btn btn-primary active" id="incoming">
+          <input type="checkbox" autocomplete="off" checked> Incoming
+        </label>
         <label class="btn btn-primary active" id="outgoing">
           <input type="checkbox"  autocomplete="off" checked> Outgoing
-        </label>
-        <label class="btn btn-primary active" id="request">
-          <input type="checkbox" autocomplete="off" checked> Request
         </label>
       </div>
 

--- a/index.html
+++ b/index.html
@@ -55,7 +55,8 @@
 
       <div id="metadata">
         Query took: <span id="duration">00000ms</span>,
-        requests: <span id="nreqs">0</span>
+        graphed entries: <span id="ngentries">0</span>,
+        total entries: <span id="ntentries">0</span>
       </div>
     </div>
 

--- a/js/graph.js
+++ b/js/graph.js
@@ -15,17 +15,19 @@
   var outgoingData = [];
   var otherData = [];
 
+  // severity and message are overridden to show the method and url,
+  // if not present.
   var $table = $('#logs').dataTable({
     columns: [
       {
         data: '@timestamp'
       },
       {
-        data: 'severity',
+        data: 'component-id',
         defaultContent: '__missing__'
       },
       {
-        data: 'component-id',
+        data: 'severity',
         defaultContent: '__missing__'
       },
       {

--- a/js/graph.js
+++ b/js/graph.js
@@ -243,7 +243,8 @@
     process(bindOutgoing, outgoingData);
     process(bindOther, otherData);
 
-    $("#nreqs").text(graphEntries);
+    $("#ngentries").text(graphEntries);
+    $("#ntentries").text(tdata.length);
 
     timelineData.forEach(function(item) {
       if (!timelineDataGroups.get(item.group)) {

--- a/js/graph.js
+++ b/js/graph.js
@@ -285,12 +285,11 @@
       console.log("Refusing " + JSON.stringify(msg));
       return;
     }
-    var timelineRequestItem;
+    var componentId = msg['component-id'];
     var title;
-    var referrer = msg.servicetype;
-    if (referrer) {
-      title = referrer + ":" + msg.url;
-    } else{
+    if (componentId) {
+      title = componentId + ":" + msg.url;
+    } else {
       title = msg.url;
     }
 
@@ -312,7 +311,7 @@
     var duration = Math.max(msg.duration/1000 || msg.durationms, 1); // hack until we all migrate
     timelineRequestItem = {
       "content": _.escape(title),
-      "group": referrer || "unknown",
+      "group": componentId || "unknown",
       "start": new Date(when - duration),
       "end": new Date(when),
       "msg": msg,

--- a/js/graph.js
+++ b/js/graph.js
@@ -9,9 +9,10 @@
   ];
   var MS_PER_DAY = 24*60*60*1000;
   var SEARCH_WINDOW = 2 * MS_PER_DAY;
+
   var tdata = [];
+  var incomingData = [];
   var outgoingData = [];
-  var requestData = [];
 
   var $table = $('#logs').dataTable({
     columns: [
@@ -52,19 +53,19 @@
     showMessage(element && element.msg);
   });
 
-  $('#toggleLogType #outgoing').on('click', function () {
-    var outgoingState = !$('#toggleLogType #outgoing').hasClass('active');
-    var requestState = $('#toggleLogType #request').hasClass('active');
-
-    bindDataToTimeline(outgoingState, requestState);
-  });
-
-  $('#toggleLogType #request').on('click', function () {
+  $('#toggleLogType #incoming').on('click', function () {
+    var incomingState = !$('#toggleLogType #incoming').hasClass('active');
     var outgoingState = $('#toggleLogType #outgoing').hasClass('active');
-    var requestState = !$('#toggleLogType #request').hasClass('active');
 
-    bindDataToTimeline(outgoingState, requestState);
+    bindDataToTimeline(incomingState, outgoingState);
   });
+  $('#toggleLogType #outgoing').on('click', function () {
+    var incomingState = $('#toggleLogType #incoming').hasClass('active');
+    var outgoingState = !$('#toggleLogType #outgoing').hasClass('active');
+
+    bindDataToTimeline(incomingState, outgoingState);
+  });
+
 
   function request(requestId, searchdate) {
     var around = Date.parse(searchdate);
@@ -144,8 +145,8 @@
     $("#duration").text(timeSpent + " ms");
 
     tdata = [];
+    incomingData = [];
     outgoingData = [];
-    requestData = [];
 
     hits.forEach(function(doc) {
       var msg = doc['_source'];
@@ -154,7 +155,7 @@
         outgoingData.push(populateTimelineRequest(msg));
         break;
       case 'request':
-        requestData.push(populateTimelineRequest(msg));
+        incomingData.push(populateTimelineRequest(msg));
         break;
       }
 
@@ -214,23 +215,23 @@
     return ret;
   }
 
-  function bindDataToTimeline(bindOutgoing, bindRequest) {
+  function bindDataToTimeline(bindOutgoing, bindIncoming) {
     timelineData.clear();
     timelineDataGroups.clear();
 
     var numberOfRequests;
-    if (bindOutgoing && !bindRequest) {
+    if (bindOutgoing && !bindIncoming) {
       numberOfRequests = outgoingData.length;
       timelineData.add(outgoingData);
     } 
-    else if (!bindOutgoing && bindRequest) {
-      numberOfRequests = requestData.length;
-      timelineData.add(requestData);
+    else if (!bindOutgoing && bindIncoming) {
+      numberOfRequests = incomingData.length;
+      timelineData.add(incomingData);
     }
-    else if (bindOutgoing && bindRequest) {
-      numberOfRequests = requestData.length + outgoingData.length;
+    else if (bindOutgoing && bindIncoming) {
+      numberOfRequests = incomingData.length + outgoingData.length;
       timelineData.add(outgoingData);
-      timelineData.add(requestData);
+      timelineData.add(incomingData);
     }
 
     $("#nreqs").text(numberOfRequests);

--- a/js/graph.js
+++ b/js/graph.js
@@ -284,7 +284,7 @@
   function populateTimelineRequest(msg) {
     var when = Date.parse(msg['@timestamp']);
     if (!when) {
-      console.log("Refusing " + JSON.stringify(msg));
+      console.log("Not populating timeline with " + JSON.stringify(msg));
       return;
     }
     var componentId = msg['component-id'];

--- a/js/graph.js
+++ b/js/graph.js
@@ -280,37 +280,36 @@
   }
 
   function populateTimelineRequest(msg) {
-    var timelineRequestItem;
     var when = Date.parse(msg['@timestamp']);
-    if (when) {
-      var title;
-      var referrer = msg.servicetype;
-      if (referrer) {
-        title = referrer + ":" + msg.url;
-      } else{
-        title = msg.url;
-      }
-      var cssClass = "httpSuccess " + msg.logname;
-      var sc = msg.status;
-      if (sc >= 300 && sc < 400) {
-        cssClass = "httpRedirect";
-      }
-      if (sc >= 400 || typeof sc === 'undefined') {
-        cssClass = "httpError";
-      }
-      var duration = Math.max(msg.duration/1000 || msg.durationms, 1); // hack until we all migrate
-      timelineRequestItem = {
-        "content": _.escape(title),
-        "group": referrer || "unknown",
-        "start": new Date(when - duration),
-        "end": new Date(when),
-        "msg": msg,
-        "className": cssClass
-      };
-    } 
-    else {
+    if (!when) {
       console.log("Refusing " + JSON.stringify(msg));
+      return;
     }
+    var timelineRequestItem;
+    var title;
+    var referrer = msg.servicetype;
+    if (referrer) {
+      title = referrer + ":" + msg.url;
+    } else{
+      title = msg.url;
+    }
+    var cssClass = "httpSuccess " + msg.logname;
+    var sc = msg.status;
+    if (sc >= 300 && sc < 400) {
+      cssClass = "httpRedirect";
+    }
+    if (sc >= 400 || typeof sc === 'undefined') {
+      cssClass = "httpError";
+    }
+    var duration = Math.max(msg.duration/1000 || msg.durationms, 1); // hack until we all migrate
+    timelineRequestItem = {
+      "content": _.escape(title),
+      "group": referrer || "unknown",
+      "start": new Date(when - duration),
+      "end": new Date(when),
+      "msg": msg,
+      "className": cssClass
+    };
     return timelineRequestItem;
   }
 

--- a/js/graph.js
+++ b/js/graph.js
@@ -1,5 +1,12 @@
 (function() {
-  var SERVERS = ["http://es-logging.otenv.com:9200/", "http://es-logging-qa.otenv.com:9200/", "http://loglov3-logging-qa.otenv.com:9200/", "http://loglov3-logging-prod.otenv.com:9200/"];
+  var SERVERS = [
+    // Legacy.
+    "http://es-logging.otenv.com:9200/",
+    "http://es-logging-qa.otenv.com:9200/",
+    // loglov3.
+    "http://loglov3-logging-qa.otenv.com:9200/",
+    "http://loglov3-logging-prod.otenv.com:9200/"
+  ];
   var MS_PER_DAY = 24*60*60*1000;
   var SEARCH_WINDOW = 2 * MS_PER_DAY;
   var tdata = [];

--- a/js/graph.js
+++ b/js/graph.js
@@ -293,14 +293,22 @@
     } else{
       title = msg.url;
     }
-    var cssClass = "httpSuccess " + msg.logname;
+
+    var cssClass;
     var sc = msg.status;
-    if (sc >= 300 && sc < 400) {
+    if (sc === undefined) {
+      cssClass = "statusOther";
+    } else if (sc >= 200 && sc < 300) {
+      cssClass = "httpSuccess";
+    } else if (sc >= 300 && sc < 400) {
       cssClass = "httpRedirect";
-    }
-    if (sc >= 400 || typeof sc === 'undefined') {
+    } else if (sc >= 400) {
       cssClass = "httpError";
+    } else {
+      // 1xx, other weird values.
+      cssClass = "statusOther";
     }
+
     var duration = Math.max(msg.duration/1000 || msg.durationms, 1); // hack until we all migrate
     timelineRequestItem = {
       "content": _.escape(title),

--- a/js/graph.js
+++ b/js/graph.js
@@ -273,7 +273,9 @@
       },
       content: {
         text: function() {
-          return _.escape($(this).text());
+          // Escape unnecessary since normalize already escapes
+          // everything.
+          return $(this).text();
         }
       }
     });
@@ -310,7 +312,8 @@
 
     var duration = Math.max(msg.duration/1000 || msg.durationms, 1); // hack until we all migrate
     timelineRequestItem = {
-      "content": _.escape(title),
+      // Escape unnecessary since normalize already escapes everything.
+      "content": title,
       "group": componentId || "unknown",
       "start": new Date(when - duration),
       "end": new Date(when),
@@ -328,7 +331,11 @@
         if (typeof value === "object") {
           value = JSON.stringify(value);
         }
-        text += "<span class=\"jk\">\"" + key + "\"</span><span class=\"jc\">: </span><span class=\"jv\">\"" + _.escape(value) + "\"</span><br/>";
+        text += "<span class=\"jk\">\"" + key +
+          "\"</span><span class=\"jc\">: </span><span class=\"jv\">\"" +
+          // Escape unnecessary since normalize already escapes
+          // everything.
+          value + "\"</span><br/>";
       });
       $('#myModal .modal-body').html(text);
       $('#myModal').modal('show');


### PR DESCRIPTION
https://opentable.atlassian.net/browse/OTPL-1657

@nchallapalli filed a ticket in which he reported some log events not showing up in timeline.  I'm not exactly sure which ones he was missing, but I figured I'd do an audit and a bit of a revamp of the tool given what I know has changed because of loglov3, and then see how the result differed from the output of the existing tool on the input he reported as problematic.

I'm pretty happy with how this turned out.  I revamped the code to normalize much earlier in the message processing flow, so a lot less escaping was required.  I also doubled up on the purpose of the columns in the taable so that both msg-v1 and http-v1 entries could be displayed usefully intertwined.

There's a little bit of documentation now displayed up top that helps users understand the tool.

In terms of Nagesh's reported request ID, the existing codebasse graphed only 12 entries, and this now finds 18.  One of the entries that appears to have been missing was FD, obviously an important one.

I still want to show Nagesh what it looks like now, since he was the reporter, and make sure this will be serving his needs.  So I'll hold off on merging until I get feedback from him.  But review in the mean time would be helpful.

I hacked all this work together, and then went back and tried to make more semantic commits, but the point-correctness is not guaranteed.  I tested this on a number of request IDs, including the one Nagesh reported, as well as some generated from fresh hits to www.opentable.com, and some that I pulled from the conserved header watchdog.