### PR TITLE
Sort Log Details by Key

### DIFF
--- a/js/graph.js
+++ b/js/graph.js
@@ -355,7 +355,7 @@
   function showMessage(msg) {
     if (msg) {
       var text = "";
-      Object.keys(msg).forEach(function(key) {
+      Object.keys(msg).sort().forEach(function(key) {
         var value = msg[key];
         if (typeof value === "object") {
           value = JSON.stringify(value);


### PR DESCRIPTION
Sorting the details window by key in order to make it easier to look for things

Before:
<img width="794" alt="before" src="https://user-images.githubusercontent.com/1636649/44125437-8392957c-a02a-11e8-9e1a-9ed303248a7a.png">

After:
<img width="846" alt="after" src="https://user-images.githubusercontent.com/1636649/44125436-836f6296-a02a-11e8-802b-92eb07ea83d8.png">
